### PR TITLE
Update token instructions to reflect GitHub changes

### DIFF
--- a/src/TokenScreen.tsx
+++ b/src/TokenScreen.tsx
@@ -27,7 +27,9 @@ export const TokenScreen: React.FC<{ token: string; onUpdate: (token: string) =>
         to list pull requests from GitHub with workflow augmentation colorization and keyboard shortcut smoothness.
       </div>
 
-      <div className="w-80 pl-5 pr-3 mb-5">Paste a GitHub Personal Access Token with repo read access to continue.</div>
+      <div className="pl-5 pr-3 mb-5 w-80">
+        Paste a GitHub Personal Access Token (classic) with repo read access to continue.
+      </div>
 
       <form
         className="mt-8"


### PR DESCRIPTION
GitHub has just launched a new type of Personal Access Token that has a more granular permission control scheme. That should be great for pullrequests.xyz! However, for a couple of reasons, the new-style PATs don't work well for the pullrequests.xyz use-case yet. Therefore, we must instead instruct users to take care to mint a "classic" PAT for pullrequests.xyz.

Here is a short list of reasons why the new style of PATs can't be used by pullrequests.xyz yet (maybe there are other limitations too that I haven't discovered yet, too):
- Can't read a user's notifications (not supported yet, it seems)
- Can't read the Pull Requests of organizations you belong to (seems to be by design?)
- Can't use the GraphQL api (this one can be worked around by just using the REST API for everything).