### PR TITLE
Add support for separate "exclude profiles"

### DIFF
--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -1,35 +1,135 @@
+import { useState } from "react";
 import { AllData } from "./api";
 import { useLocalStorage } from "./utils";
 
-export const Settings: React.FC<{ allData: AllData }> = () => {
-  const [excludes, setExcludes] = useLocalStorage<string[]>("pullrequests.xyz_settings_excludes", []);
+export type ExcludeProfile = {
+  displayName: string;
+  excludes: string[];
+};
+
+type SettingsProps = {
+  excludeProfiles: ExcludeProfile[];
+  setExcludeProfiles: (updater: (old: ExcludeProfile[]) => ExcludeProfile[]) => void;
+  currentExcludeProfileIndex: number;
+  setCurrentExcludeProfileIndex: (updater: (old: number) => number) => void;
+};
+
+export const Settings: React.FC<SettingsProps> = ({
+  excludeProfiles,
+  setExcludeProfiles,
+  currentExcludeProfileIndex,
+  setCurrentExcludeProfileIndex,
+}) => {
+  const [editingDisplayNames, setEditingDisplayNames] = useState<number[]>([]);
 
   return (
     <div className="container p-3 mx-auto">
       <div className="mb-5 text-xl font-bold">Settings</div>
-
       <div className="mb-3 font-bold">Exclude repositories</div>
-      <div className="mb-3">Add repository excludes here.</div>
-
-      {excludes.concat([""]).map((exclude, i) => {
+      <div className="mb-3">
+        Add repository excludes here. <br />
+        You can keep excludes in separate profiles that you can switch between from the top menu.
+      </div>
+      {excludeProfiles.map((profile, profileIndex) => {
+        const excludes = profile.excludes;
         return (
-          <div>
-            <input
-              type="text"
-              value={exclude}
-              onChange={(e) => {
-                setExcludes((old: string[]) => {
-                  let newValue = (old || []).slice();
-                  newValue[i] = e.target.value;
-                  newValue = newValue.filter((x) => x);
-                  return newValue;
-                });
-              }}
-              className="px-5 py-2 mb-3 border rounded-full dark:text-gray-300 dark:bg-black dark:bg-opacity-30 dark:border-opacity-0"
-            />
+          <div className="p-5 my-3 rounded-3xl bg-gray-200 dark:bg-gray-800" key={profileIndex}>
+            <div
+              className="mb-3 border-b-2 border-dotted border-b-slate-700"
+              style={{ display: "flex", justifyContent: "space-between" }}
+            >
+              {editingDisplayNames.includes(profileIndex) ? (
+                <div>
+                  <input
+                    type="text"
+                    value={profile.displayName}
+                    onChange={(e) => {
+                      setExcludeProfiles((old) => {
+                        return [
+                          ...old.slice(0, profileIndex),
+                          { displayName: e.target.value, excludes: [...profile.excludes] },
+                          ...old.slice(profileIndex + 1),
+                        ];
+                      });
+                    }}
+                    autoFocus
+                    className="px-5 py-2 mb-3 border rounded-full dark:text-gray-300 dark:bg-black dark:bg-opacity-30 dark:border-opacity-0"
+                  />
+                  <button
+                    onClick={() => setEditingDisplayNames((old) => old.filter((it) => it !== profileIndex))}
+                    className="ml-3 hover:underline"
+                  >
+                    Done
+                  </button>
+                </div>
+              ) : (
+                <span>{profile.displayName}</span>
+              )}
+              <div>
+                {!editingDisplayNames.includes(profileIndex) && (
+                  <button
+                    className="mr-2 hover:underline"
+                    onClick={() => setEditingDisplayNames((old) => [...old, profileIndex])}
+                  >
+                    Rename
+                  </button>
+                )}
+                <button
+                  className="mr-2 hover:underline"
+                  onClick={() => {
+                    if (window.confirm(`Are you sure you want to delete profile ${profile.displayName}?`)) {
+                      setExcludeProfiles((old) => {
+                        return [...old.slice(0, profileIndex), ...old.slice(profileIndex + 1)];
+                      });
+                      if (currentExcludeProfileIndex > profileIndex) {
+                        setCurrentExcludeProfileIndex((old) => old - 1);
+                      } else if (currentExcludeProfileIndex === profileIndex) {
+                        setCurrentExcludeProfileIndex(() => 0);
+                      }
+                    }
+                  }}
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+            {excludes.concat([""]).map((exclude, repoIndex) => {
+              return (
+                <div key={`${profileIndex}-${repoIndex}`}>
+                  <input
+                    type="text"
+                    value={exclude}
+                    onChange={(e) => {
+                      setExcludeProfiles((old: ExcludeProfile[]) => {
+                        let newExcludes = (old[profileIndex].excludes || []).slice();
+                        newExcludes[repoIndex] = e.target.value;
+                        newExcludes = newExcludes.filter((x) => x);
+                        return [
+                          ...old.slice(0, profileIndex),
+                          { displayName: profile.displayName, excludes: newExcludes },
+                          ...old.slice(profileIndex + 1),
+                        ];
+                      });
+                    }}
+                    style={{ width: 300 }}
+                    className="px-5 py-2 mb-3 border rounded-full dark:text-gray-300 dark:bg-black dark:bg-opacity-30 dark:border-opacity-0"
+                  />
+                </div>
+              );
+            })}
           </div>
         );
       })}
+      <div className="p-5 my-3 rounded-3xl bg-gray-200 dark:bg-gray-800" key="add-new">
+        <button
+          onClick={() => {
+            setEditingDisplayNames((old) => [...old, excludeProfiles.length]);
+            setExcludeProfiles((old) => [...old, { displayName: "New profile", excludes: [] }]);
+          }}
+        >
+          ⊕ Add profile
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Instead of maintaining one list of excludes, this allows you to have several
profiles for different use cases (e.g. if you focus on different teams/areas) at
different times.

- The `excludes` list is deprecated, but read at boot and fed into the new
  format if necessary
- The set of exclude profiles is stored as a list in localstorage together with
  the index of the currently selected profile
- A picker is placed in the top menu on the screen to switch between them
- The settings screen is updated to take data from the main app and show a list
  of profiles that are editable

One potential next step that is not included here is to allow setting the
profile via query param, to allow saving bookmarks to particular views.

(This might need some UI emergency help – I haven't gotten my
`position: absolute`-license yet)

<img width="400" alt="image" src="https://user-images.githubusercontent.com/5347151/197361477-ba7b295f-dc0e-4127-bcca-6e3db99dbe82.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/5347151/197361562-d4c3cbd3-7b1a-460d-9c61-2259fa4137d8.png">
<img width="204" alt="image" src="https://user-images.githubusercontent.com/5347151/197361571-5657f1f3-2bea-4ce9-8f47-a4cc575de555.png">
<img width="242" alt="image" src="https://user-images.githubusercontent.com/5347151/197361586-cedabbb0-aa57-4168-a311-186259d3fe92.png">
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/5347151/197361603-60b24eb0-c53d-4590-817b-e993c909691c.png">


